### PR TITLE
Spell effect text files refactor

### DIFF
--- a/Scripts/Source/MantellaTargetListenerScript.psc
+++ b/Scripts/Source/MantellaTargetListenerScript.psc
@@ -107,20 +107,6 @@ Event OnObjectUnequipped(Form akBaseObject, ObjectReference akReference)
 endEvent
 
 
-Event OnSit(ObjectReference akFurniture)
-    String selfName = self.GetActorReference().getdisplayname()
-    ;Debug.MessageBox(selfName+" sat down.")
-    MiscUtil.WriteToFile("_mantella_in_game_events.txt", selfName+" sat down.\n")
-endEvent
-
-
-Event OnGetUp(ObjectReference akFurniture)
-    String selfName = self.GetActorReference().getdisplayname()
-    ;Debug.MessageBox(selfName+" stood up.")
-    MiscUtil.WriteToFile("_mantella_in_game_events.txt", selfName+" stood up.\n")
-EndEvent
-
-
 Event OnDying(Actor akKiller)
     MiscUtil.WriteToFile("_mantella_end_conversation.txt", "True",  append=false)
 EndEvent


### PR DESCRIPTION
Refactored the Mantella spell's text files to prioritise listening for `_mantella_say_line.txt`:
1. Merged `_mantella_listening.txt`, `_mantella_thinking.txt`, and `_mantella_error_check.txt` into one file called `_mantella_status.txt` . This file is evaluated once every 5 loops instead of once every loop
2. Condensed `_mantella_say_line.txt` and `_mantella_subtitle.txt` into one file. Now the subtitle text gets passed directly to `_mantella_say_line.txt`, removing the need for an extra file. This file's value is still set to "False" when not in use
3. `_mantella_aggro.txt` and `_mantella_in_game_time.txt` are now only processed when `_mantella_say_line.txt` is triggered instead of once every loop
4. `_mantella_text_input_enabled.txt` (used to start the textbox timer) is now evaluated once every 5 loops instead of once every loop

Also removed the sit / stand listen events for NPCs as these were triggered too frequently