### PR TITLE
Fixed wording of sit message

### DIFF
--- a/Scripts/Source/MantellaListenerScript.psc
+++ b/Scripts/Source/MantellaListenerScript.psc
@@ -216,7 +216,7 @@ Event OnSit(ObjectReference akFurniture)
     if repository.playerTrackingOnSit
         ;Debug.MessageBox("The player sat down.")
         String furnitureName = akFurniture.getbaseobject().getname()
-        MiscUtil.WriteToFile("_mantella_in_game_events.txt", "The player sat down / rested on a(n) "+furnitureName+".\n")
+        MiscUtil.WriteToFile("_mantella_in_game_events.txt", "The player rested on / used a(n) "+furnitureName+".\n")
     endif
 endEvent
 


### PR DESCRIPTION
Fixed "the player sat down / rested on" to "the player rested on / used" to avoid the badly worded message "the player sat down / rested on wood chopping block".