### PR TITLE
Fixed sat down / rested on message for target

### DIFF
--- a/Scripts/Source/MantellaTargetListenerScript.psc
+++ b/Scripts/Source/MantellaTargetListenerScript.psc
@@ -141,7 +141,7 @@ Event OnSit(ObjectReference akFurniture)
         String furnitureName = akFurniture.getbaseobject().getname()
         ; only save event if actor is sitting / resting on furniture (and not just, for example, leaning on a bar table)
         if furnitureName != ""
-            MiscUtil.WriteToFile("_mantella_in_game_events.txt", selfName+" sat down / rested on a(n) "+furnitureName+".\n")
+            MiscUtil.WriteToFile("_mantella_in_game_events.txt", selfName+" rested on / used a(n) "+furnitureName+".\n")
         endIf
     endif
 endEvent


### PR DESCRIPTION
Fixed "target sat down / rested on" to "target rested on / used" to avoid the badly worded message "target sat down / rested on wood chopping block".