### PR TITLE
Compatibility with update 1130 by adding UIExtensions scripts explicitly to project build

### DIFF
--- a/skyrimse.ppj
+++ b/skyrimse.ppj
@@ -20,6 +20,7 @@
         <Import>C:\Games\Steam\steamapps\common\Skyrim Special Edition\Data\Scripts\Source</Import>
         <Import>C:\Modding\MO2\mods\SKSE64\Scripts\Source</Import>
         <Import>C:\Modding\MO2\mods\PapyrusUtil SE - Modders Scripting Utility Functions\Scripts\Source</Import>
+        <Import>C:\Modding\MO2\mods\UIExtensions\scripts\source</Import>
     </Imports>
     <Folders>
         <!-- Relative path to folder containing .psc Papyrus source code files for this project -->


### PR DESCRIPTION
Extracted UIExtensions's script files with [BAE](https://www.nexusmods.com/fallout4/mods/78) and imported them to the project build .ppj. This is because of some issue with Skyrim's latest update