### PR TITLE
Actor and context data caching

### DIFF
--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -585,8 +585,10 @@ int[] function BuildNpcsInConversationArray()
     return actorHandles
 endFunction
 
-int function buildActorSetting(Actor actorToBuild)    
+int function buildActorSetting(Actor actorToBuild)  
+    Debug.Trace("buildActorSetting start: " + Utility.GetCurrentGameTime())  
     int handle = SKSE_HTTP.createDictionary()
+    Debug.Trace("int handle = SKSE_HTTP.createDictionary(): " + Utility.GetCurrentGameTime())  
     SKSE_HTTP.setInt(handle, mConsts.KEY_ACTOR_ID, (actorToBuild.getactorbase() as form).getformid())
     SKSE_HTTP.setString(handle, mConsts.KEY_ACTOR_NAME, GetActorName(actorToBuild))
     bool isPlayerCharacter = actorToBuild == PlayerRef
@@ -597,12 +599,17 @@ int function buildActorSetting(Actor actorToBuild)
     SKSE_HTTP.setString(handle, mConsts.KEY_ACTOR_VOICETYPE, actorToBuild.GetVoiceType())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISENEMY, actorToBuild.getcombattarget() == PlayerRef)
+    Debug.Trace("set values: " + Utility.GetCurrentGameTime())  
     EquipmentDescriber.AddEquipmentDescription(handle, actorToBuild)
+    Debug.Trace("added equipment: " + Utility.GetCurrentGameTime())  
     int customActorValuesHandle = SKSE_HTTP.createDictionary()
     If (isPlayerCharacter)
+        Debug.Trace("Adding CustomPCValues: " + Utility.GetCurrentGameTime())  
         AddCustomPCValues(customActorValuesHandle, actorToBuild)
+        Debug.Trace("Added CustomPCValues: " + Utility.GetCurrentGameTime())  
     EndIf
     SKSE_HTTP.setNestedDictionary(handle, mConsts.KEY_ACTOR_CUSTOMVALUES, customActorValuesHandle)
+    Debug.Trace("setNestedDictionaryt: " + Utility.GetCurrentGameTime())  
     return handle
 endFunction
 
@@ -622,13 +629,13 @@ EndFunction
 
 int function BuildContext(bool isConversationStart = false)
     int handle = SKSE_HTTP.createDictionary()
-    if (isConversationStart || repository.playerTrackingOnLocationChange)
+    if (isConversationStart)
         _location = ((Participants.GetAt(0) as Actor).GetCurrentLocation() as Form).getName()
         if _location == ""
             _location = "Skyrim"
         endIf
+        SKSE_HTTP.setString(handle, mConsts.KEY_CONTEXT_LOCATION, _location)
     endIf
-    SKSE_HTTP.setString(handle, mConsts.KEY_CONTEXT_LOCATION, _location)
 
     if (isConversationStart || repository.playerTrackingOnWeatherChange)
         AddCurrentWeather(handle)

--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -567,13 +567,9 @@ EndFunction
 
 Function AddCurrentActorsAndContext(int handleToAddTo, bool isConversationStart = false)
     ;Add Actors
-    Debug.Trace("Building actors...")
     SKSE_HTTP.setNestedDictionariesArray(handleToAddTo, mConsts.KEY_ACTORS, _actorHandles)
-    Debug.Trace("Built actors.")
     ;add context
-    Debug.Trace("Building context...")
     SKSE_HTTP.setNestedDictionary(handleToAddTo, mConsts.KEY_CONTEXT, _contextHandle)
-    Debug.Trace("Built context.")
 EndFunction
 
 int[] function BuildNpcsInConversationArray()
@@ -586,9 +582,7 @@ int[] function BuildNpcsInConversationArray()
 endFunction
 
 int function buildActorSetting(Actor actorToBuild)  
-    Debug.Trace("buildActorSetting start: " + Utility.GetCurrentGameTime())  
     int handle = SKSE_HTTP.createDictionary()
-    Debug.Trace("int handle = SKSE_HTTP.createDictionary(): " + Utility.GetCurrentGameTime())  
     SKSE_HTTP.setInt(handle, mConsts.KEY_ACTOR_ID, (actorToBuild.getactorbase() as form).getformid())
     SKSE_HTTP.setString(handle, mConsts.KEY_ACTOR_NAME, GetActorName(actorToBuild))
     bool isPlayerCharacter = actorToBuild == PlayerRef
@@ -599,17 +593,12 @@ int function buildActorSetting(Actor actorToBuild)
     SKSE_HTTP.setString(handle, mConsts.KEY_ACTOR_VOICETYPE, actorToBuild.GetVoiceType())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISENEMY, actorToBuild.getcombattarget() == PlayerRef)
-    Debug.Trace("set values: " + Utility.GetCurrentGameTime())  
     EquipmentDescriber.AddEquipmentDescription(handle, actorToBuild)
-    Debug.Trace("added equipment: " + Utility.GetCurrentGameTime())  
     int customActorValuesHandle = SKSE_HTTP.createDictionary()
     If (isPlayerCharacter)
-        Debug.Trace("Adding CustomPCValues: " + Utility.GetCurrentGameTime())  
         AddCustomPCValues(customActorValuesHandle, actorToBuild)
-        Debug.Trace("Added CustomPCValues: " + Utility.GetCurrentGameTime())  
     EndIf
     SKSE_HTTP.setNestedDictionary(handle, mConsts.KEY_ACTOR_CUSTOMVALUES, customActorValuesHandle)
-    Debug.Trace("setNestedDictionaryt: " + Utility.GetCurrentGameTime())  
     return handle
 endFunction
 

--- a/Scripts/Source/MantellaListenerScript.psc
+++ b/Scripts/Source/MantellaListenerScript.psc
@@ -194,7 +194,13 @@ Event OnLocationChange(Location akOldLoc, Location akNewLoc)
     ; check if radiant dialogue is playing, and end conversation if the player leaves the area
     If (conversation.IsRunning() && !conversation.IsPlayerInConversation())
         conversation.EndConversation()
-    EndIf
+    elseIf repository.playerTrackingOnLocationChange
+        string _location = (akNewLoc as Form).GetName()
+        if _location == ""
+            _location = "Skyrim"
+        endIf
+        AddIngameEventToConversation("The location is now " + _location)
+    endIf
 endEvent
 
 


### PR DESCRIPTION
- Set actor handles and context handle to global variables, removing the need to refresh the contained values every time they are needed
- Actor handles are only updated at the start of a conversation, when an NPC is added, and when an NPC is removed (and not updated on every voiceline)
- Context hanlde data are only updated when a request for a player response is set (and not updated on every voiceline)
- Location is only updated when OnLocationChange is triggered (and not every time context data are updated)