### PR TITLE
Reduced the wait time for an NPC to finish speaking

### DIFF
--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -339,7 +339,7 @@ function WaitForSpecificNpcToFinishSpeaking(Actor selectedNpc)
     while _isTalking == true ; wait until the NPC has finished speaking
         Utility.Wait(waitTime)
         totalWaitTime += waitTime
-        if totalWaitTime > 20
+        if totalWaitTime > 10 ; note that this isn't really in seconds due to the overhead of the loop running
             Debug.Notification("NPC speaking too long, ending wait...")
             _isTalking = false
         endIf


### PR DESCRIPTION
Sometimes there are problems when waiting for an NPC to finish speaking where it never returns true. In these cases, the code should stop waiting after a certain amount of time.