### PR TITLE
Added request to initialize Mantella server settings

### DIFF
--- a/Scripts/Source/MantellaConstants.psc
+++ b/Scripts/Source/MantellaConstants.psc
@@ -26,11 +26,13 @@ string property KEY_REPLYTYPE = "mantella_reply_type" auto
 string property KEY_REQUEST_EXTRA_ACTIONS = "mantella_extra_actions" auto
 
 ;Conversation
+string property KEY_REQUESTTYPE_INIT = "mantella_initialize" auto
 string property KEY_REQUESTTYPE_STARTCONVERSATION = "mantella_start_conversation" auto
 string property KEY_REQUESTTYPE_CONTINUECONVERSATION = "mantella_continue_conversation" auto
 string property KEY_REQUESTTYPE_PLAYERINPUT = "mantella_player_input" auto
 string property KEY_REQUESTTYPE_ENDCONVERSATION = "mantella_end_conversation" auto
 
+string property KEY_REPLYTTYPE_INITCOMPLETED = "mantella_init_completed" auto
 string property KEY_REPLYTTYPE_STARTCONVERSATIONCOMPLETED = "mantella_start_conversation_completed" auto
 
 string property KEY_REPLYTYPE_NPCTALK = "mantella_npc_talk" auto


### PR DESCRIPTION
When a conversation is started, gathering actor and context information to pass to the Mantella server takes time. A new request called `mantella_initialize` has been created to force Mantella's server settings to initialize (setting up LLM, starting TTS service, loading CSVs, etc) as soon as a conversation has been triggered. This means the server can now pre-prepare for a request while the Papyrus code gathers the necessary information for the conversation to save time.

See here for the Mantella Software implementation of this request type: https://github.com/art-from-the-machine/Mantella/pull/428