### PR TITLE
Response time improvements

### DIFF
--- a/Scripts/Source/MantellaMCM.psc
+++ b/Scripts/Source/MantellaMCM.psc
@@ -70,6 +70,7 @@ int property oid_targetTrackingOnObjectUnequippedToggle auto
 int property oid_targetTrackingOnSitToggle auto
 int property oid_targetTrackingOnGetUpToggle auto
 int property oid_targetTrackingOnDyingToggle auto
+int property oid_targetTrackingAngerStateToggle auto
 int property oid_targetTrackingAll auto
 bool property targetAllToggle auto
 
@@ -330,6 +331,8 @@ Event OnOptionHighlight (Int optionID)
 		SetInfoText("Tracks furniture stood up from while a Mantella conversation is active.")
 	elseIf optionID == oid_targetTrackingOnGetUpToggle	
 		SetInfoText("Enable / disable all tracking options for the target.")
+	elseIf optionID == oid_targetTrackingAngerStateToggle	
+		SetInfoText("Tracks anger state of target (used to apply anger emotions to xVASynth output). Causes minor response delays.")
 
     elseIf optionID == oid_targetEquipmentBody	
 		SetInfoText("Describe item in the body slot (32) of the target to the LLM.")

--- a/Scripts/Source/MantellaMCM_TargetTrackingSettings.psc
+++ b/Scripts/Source/MantellaMCM_TargetTrackingSettings.psc
@@ -21,6 +21,7 @@ function LeftColumn(MantellaMCM mcm, MantellaRepository Repository) global
     mcm.oid_targetTrackingOnObjectUnequippedToggle = mcm.AddToggleOption("Item Unequipped", Repository.targetTrackingOnObjectUnequipped)
     mcm.oid_targetTrackingOnSitToggle = mcm.AddToggleOption("Target Rests on Furniture", Repository.targetTrackingOnSit)
     mcm.oid_targetTrackingOnGetUpToggle = mcm.AddToggleOption("Target Gets Up from Furniture", Repository.targetTrackingOnGetUp)
+    mcm.oid_targetTrackingAngerStateToggle = mcm.AddToggleOption("Target Anger State", Repository.targetTrackingAngerState)
     mcm.oid_targetTrackingAll = mcm.AddToggleOption("All", mcm.targetAllToggle)
 endfunction
 
@@ -113,6 +114,9 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
     ElseIf optionID==mcm.oid_targetTrackingOnGetUpToggle
         Repository.targetTrackingOnGetUp=!Repository.targetTrackingOnGetUp
         mcm.SetToggleOptionValue( mcm.oid_targetTrackingOnGetUpToggle, Repository.targetTrackingOnGetUp)
+    ElseIf optionID==mcm.oid_targetTrackingAngerStateToggle
+        Repository.targetTrackingAngerState=!Repository.targetTrackingAngerState
+        mcm.SetToggleOptionValue( mcm.oid_targetTrackingAngerStateToggle, Repository.targetTrackingAngerState)
     ElseIf optionID==mcm.oid_targetTrackingAll
         ;This part of the function OptionUpdate flips a bunch of variables in the repository at once :
         mcm.targetAllToggle=!mcm.targetAllToggle
@@ -126,6 +130,7 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
         mcm.SetToggleOptionValue( mcm.oid_targetTrackingOnObjectUnequippedToggle, mcm.targetAllToggle)
         mcm.SetToggleOptionValue( mcm.oid_targetTrackingOnSitToggle, mcm.targetAllToggle)
         mcm.SetToggleOptionValue( mcm.oid_targetTrackingOnGetUpToggle, mcm.targetAllToggle)
+        mcm.SetToggleOptionValue( mcm.oid_targetTrackingAngerStateToggle, mcm.targetAllToggle)
         
         Repository.targetTrackingItemAdded=mcm.targetAllToggle
         Repository.targetTrackingItemRemoved=mcm.targetAllToggle
@@ -136,6 +141,7 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
         Repository.targetTrackingOnObjectUnequipped=mcm.targetAllToggle
         Repository.targetTrackingOnSit=mcm.targetAllToggle
         Repository.targetTrackingOnGetUp=mcm.targetAllToggle
+        Repository.targetTrackingAngerState=mcm.targetAllToggle
         ;not using dying toggle cause this one is to end conversations on NPC death
         ;Repository.targetTrackingOnDying=mcm.targetAllToggle
         

--- a/Scripts/Source/MantellaRepository.psc
+++ b/Scripts/Source/MantellaRepository.psc
@@ -79,6 +79,7 @@ bool property targetTrackingOnObjectEquipped auto
 bool property targetTrackingOnObjectUnequipped auto
 bool property targetTrackingOnSit auto
 bool property targetTrackingOnGetUp auto
+bool property targetTrackingAngerState auto
 
 bool property targetEquipmentBody auto
 bool property targetEquipmentHead auto
@@ -192,6 +193,7 @@ function assignDefaultSettings(int lastVersion, bool isFirstInit = false)
         targetTrackingOnObjectUnequipped = true
         targetTrackingOnSit = true
         targetTrackingOnGetUp = true
+        targetTrackingAngerState = true
 
         targetEquipmentBody = true
         targetEquipmentHead = true


### PR DESCRIPTION
Every time a response is provided by the player, the array of actors in the conversation (`UpdateNpcsInConversationArray()`) as well as in-game context information (`BuildContext()`) are updated along with the player's response. These functions cause a delay in the NPC's response time.

`UpdateNpcsInConversationArray()` is only used to update the combat state of each actor, which is then used to add an anger emotion to xVASynth voicelines. Rather than being enabled by default, an optional setting has been added to Mantella's MCM menu to enable this feature.

To "hide" the response delay caused by running `BuildContext()`, this function is now called when the text box hotkey is pressed. This causes a minor delay in opening the UIExtensions text box, but removes the delay after the player sends the response.