### PR TITLE
Speech-to-text improvements

### DIFF
--- a/Scripts/Source/MantellaConstants.psc
+++ b/Scripts/Source/MantellaConstants.psc
@@ -22,6 +22,7 @@ string property HTTP_ERROR = "SKSE_HTTP_error" auto
 string property PREFIX = "mantella_" auto
 string property KEY_REQUESTTYPE = "mantella_request_type" auto
 string property KEY_REPLYTYPE = "mantella_reply_type" auto
+string property KEY_INPUTTYPE = "mantella_input_type" auto
 
 string property KEY_REQUEST_EXTRA_ACTIONS = "mantella_extra_actions" auto
 
@@ -81,6 +82,9 @@ string property KEY_CONTEXT_INGAMEEVENTS = "mantella_ingame_events" auto
 string property KEY_REQUESTTYPE_TTS = "mantella_tts" auto
 string property KEY_INPUT_NAMESINCONVERSATION = "mantella_names_in_conversation" auto
 string property KEY_TRANSCRIBE = "mantella_transcribe" auto
+string property KEY_INPUTTYPE_TEXT = "mantella_text_input" auto
+string property KEY_INPUTTYPE_MIC = "mantella_mic_input" auto
+string property KEY_INPUTTYPE_PTT = "mantella_push_to_talk" auto
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;       Possible actions      ;


### PR DESCRIPTION
- Added mic input value to start conversation request to allow the server to initialize mic settings in advance
- Added functionality to only update actor context when these values have been updated
- Removed wait once voiceline is played to speed up communication with the server
- Removed fetching of actor names for mic request (this is now handled on the server side)