### PR TITLE
Remove wait for voice folder to change

### DIFF
--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -258,9 +258,6 @@ function ProcessNpcSpeak(int handle)
                 VoiceType orgRaceDefaultVoice = SKSE_HTTP.GetRaceDefaultVoiceType(speaker)
                 SKSE_HTTP.SetRaceDefaultVoiceType(speaker,MantellaVoice00)
 
-                ; Do not play the voiceline until the speaker's voice folder has been changed
-                WaitForVoiceAssignment(speaker, isPlayer)
-
                 NpcSpeak(speaker, lineToSpeak, topicToUse, false, lineDuration)
                 SKSE_HTTP.SetRaceDefaultVoiceType(speaker,orgRaceDefaultVoice)
             else
@@ -268,9 +265,6 @@ function ProcessNpcSpeak(int handle)
                 ; Debug.Trace((Utility.GetCurrentRealTime() - httpReceivedTime) + " seconds to get orinal voice type", 2)
                 SKSE_HTTP.SetVoiceType(speaker, MantellaVoice00)
                 ; Debug.Trace((Utility.GetCurrentRealTime() - httpReceivedTime) + " seconds to set voice type", 2)
-                
-                ; Do not play the voiceline until the speaker's voice folder has been changed
-                WaitForVoiceAssignment(speaker, isPlayer)
 
                 NpcSpeak(speaker, lineToSpeak, topicToUse, isNarration, lineDuration)
                 SKSE_HTTP.SetVoiceType(speaker, orgVoice)


### PR DESCRIPTION
Removed wait for voice folder to change as this change does not fix issues for players who experience voice folders not changing. An option has been added to the Mantella UI for these players here: https://github.com/art-from-the-machine/Mantella/commit/8123dc4ad5a0db50b333a9808328b8892b3d6299