### PR TITLE
Add Vanilla Dialogue Awareness

### DIFF
--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -108,6 +108,7 @@ function StartConversation(Actor[] actorsToStartConversationWith)
     if (eventHandle)        
         ModEvent.Send(eventHandle)
     endIf 
+    MantellaVanillaDialogue.notifyConversationStart()
 endFunction
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -369,6 +370,7 @@ Function CleanupConversation()
     if (handle)        
         ModEvent.Send(handle)
     endIf 
+    MantellaVanillaDialogue.notifyConversationEnd()
     Debug.Notification("Conversation ended.")  
     Stop()
 EndFunction
@@ -557,6 +559,7 @@ Function SendActorAddedEvents(Form[] actorsAdded)
         EndIf
         index += 1
     EndWhile
+    MantellaVanillaDialogue.notifyNpcAdded(actorsAdded)
 EndFunction
 
 Function SendActorRemovedEvents(Form[] actorsRemoved)
@@ -570,6 +573,7 @@ Function SendActorRemovedEvents(Form[] actorsRemoved)
         endIf 
         index += 1
     EndWhile
+    MantellaVanillaDialogue.notifyNpcRemoved(actorsRemoved)
 EndFunction
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/Scripts/Source/MantellaMCM.psc
+++ b/Scripts/Source/MantellaMCM.psc
@@ -89,6 +89,7 @@ int property oid_AllowForNPCtoFollowToggle auto ;gia
 int property oid_NPCAngerToggle auto ;gia
 int property oid_NPCInventoryToggle auto
 int property oid_NPCPackageToggle auto
+int property oid_enableVanillaDialogueAwareness auto
 
 int property oid_debugNPCSelectMode auto
 int property oid_restartMantellaExe Auto
@@ -111,7 +112,7 @@ string MantellaMCMcurrentPage
 ; Whenever a new repository value OR a new MCM setting is added, up the MCM version number returned by `ManatellaMCM.GetVersion()`
 ; and add the corresponding default value in 'MCMRepository.assignDefaultSettings' in a block corresponding to the version number like the examples
 int Function GetVersion()
-    Return 6
+    Return 7
 EndFunction
 
 event OnVersionUpdate(int a_version)
@@ -360,6 +361,8 @@ Event OnOptionHighlight (Int optionID)
 		SetInfoText("NPCs can open their inventory to share items.")
 	elseIf optionID == oid_NPCPackageToggle
 		SetInfoText("NPCs will stop to talk to you and will not engage in non-Mantella conversations.")
+	elseIf optionID == oid_enableVanillaDialogueAwareness
+		SetInfoText("NPCs will know about any dialogue spoken in the vanilla dialogue system.")
 
 	elseIf optionID == oid_debugNPCSelectMode
 		SetInfoText("Allows the player to speak to any NPC by initiating a conversation then entering the actor RefID and actor name that the player wishes to speak to")

--- a/Scripts/Source/MantellaMCM_GeneralSettings.psc
+++ b/Scripts/Source/MantellaMCM_GeneralSettings.psc
@@ -15,6 +15,7 @@ function LeftColumn(MantellaMCM mcm, MantellaRepository Repository) global
     mcm.oid_showReminderMessages = mcm.AddToggleOption("Show Input Reminder Messages", repository.showReminderMessages)
 
     mcm.AddHeaderOption("Controls")
+    mcm.oid_enableVanillaDialogueAwareness = mcm.AddToggleOption("Enable Vanilla Dialogue Awareness", repository.enableVanillaDialogueAwareness)
     mcm.oid_keymapStartAddHotkey = mcm.AddKeyMapOption("Start Conversation / Add NPC", repository.MantellaStartHotkey)
     mcm.oid_keymapPromptHotkey = mcm.AddKeyMapOption("Open Text Prompt", repository.MantellaListenerTextHotkey)
     mcm.oid_keymapEndHotkey = mcm.AddKeyMapOption("End Conversation / Remove NPC", repository.MantellaEndHotkey)
@@ -157,5 +158,8 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
     elseIf optionID == mcm.oid_NPCPackageToggle
         Repository.NPCPackage =! Repository.NPCPackage
         mcm.SetToggleOptionValue(mcm.oid_NPCPackageToggle, Repository.NPCPackage)
+    elseIf optionID == mcm.oid_enableVanillaDialogueAwareness
+        Repository.enableVanillaDialogueAwareness =! Repository.enableVanillaDialogueAwareness
+        mcm.SetToggleOptionValue(mcm.oid_enableVanillaDialogueAwareness, Repository.enableVanillaDialogueAwareness)
     endif
 endfunction

--- a/Scripts/Source/MantellaRepository.psc
+++ b/Scripts/Source/MantellaRepository.psc
@@ -89,7 +89,7 @@ bool property targetEquipmentAmulet auto
 bool property targetEquipmentRightHand auto
 bool property targetEquipmentLeftHand auto
 
-
+bool property enableVanillaDialogueAwareness auto
 bool property AllowForNPCtoFollow auto ;gia
 ;bool property followingNPCsit auto ;gia
 ;bool property followingNPCsleep auto ;gia
@@ -121,6 +121,9 @@ endEvent
 ; and add the corresponding default value here in a block corresponding to the version number like the examples below
 ; Doing it like this will only assign the defaul values to settings that haven't been initialised prior.
 function assignDefaultSettings(int lastVersion, bool isFirstInit = false)
+    If (lastVersion < 7 || isFirstInit)
+        enableVanillaDialogueAwareness = true
+    EndIf
     If (lastVersion < 6 || isFirstInit)
         NPCInventory = false
     EndIf

--- a/Scripts/Source/MantellaVanillaDialogue.psc
+++ b/Scripts/Source/MantellaVanillaDialogue.psc
@@ -1,0 +1,7 @@
+scriptname MantellaVanillaDialogue hidden
+
+;Forwards event to the SKSE Dialogue tracker 
+    function notifyConversationStart() global native
+    function notifyConversationEnd() global native
+    function notifyNpcAdded(Form[] added) global native
+    function notifyNpcRemoved(Form[] removed) global native


### PR DESCRIPTION
Adds an option to the MCM that when enabled makes Mantella conversations aware of things said in the vanilla dialogue system through the Event system.

Excerpt from ysolda.json to how vanilla dialogue is added. 
```
        {
            "role": "user",
            "content": "(Prisoner: What do you know of the Khajiit?; Ysolda: About the same as everyone else. They're the cat-folk of Elsweyr. Great warriors, good traders. The way I hear it, Elsweyr ain't nothing like Skyrim. It's got tropical forests and dusty badlands. It sounds awful!) I'm sorry, I was just debugging, don't take it personally."
        },
```

## How it works
_Player selects a line to say in the dialogue menu_
**Player is in a mantella conversation with that npc** -> AddEvent is called

**Player is not in a conversation** -> Dialogue Exchange gets stored to SKSE save file and sent the next time a Mantella conversation with that NPC starts

**Player is in a conversation, but the NPC they are in dialogue with is not part of it** -> AddEvent is called & the voiceline is stored and resent when that NPC enters the conversation or a conversation with them is started

---

Note: As soon as a dialogue item is selected by the player, all the sentences get sent to Mantella that the NPC will say in response. even if the player exits the conversation early, Mantella will still be aware of all the lines the NPC would have said.

## SKSE Plugin

All the logic for this is in an SKSE plug-in, The code for which can be found [here](https://github.com/mikastamm/mantella-vanilla-dialogue).

## Configuration

There are some extra configuration options possible through the `SKSE/Plugins/MantellaDialogue.ini` file.

```ini
; Toggles Dialogue Tracking (Also available in MCM)
EnableVanillaDialogueTracking=true

; If the NPC's reply is less than FilterShortRepliesMinWordCount, Do not send it to Mantella.
; can help filter out some menus and mod related dialogue options.
FilterShortReplies=false
FilterShortRepliesMinWordCount=4
; filters all player lines and npc responses for greetings that are non unique (ie. can be triggered each time the player starts a conversation with that NPC.)
FilterNonUniqueGreetings=true
; If the NPCs response or line is included in one of these, discard both the player's line and the NPCs line.
NPCLineBlacklist=Can I help you?, Farewell, See you later
; If the players line is included in these, discard both the players and the NPCs line.
PlayerLineBlacklist=Stage1Hello, I want you to.., Goodbye. (Remove from Mantella conversation), DialogueGenericHello

; Add the names of the NPCs here for which you do not want to track dialogue (comma seperated)
; The Names must be the same as they appear in the game.
NPCNamesToIgnore=
```

