### PR TITLE
Add additional hotkey functionality

### DIFF
--- a/Scripts/Source/MantellaMCM.psc
+++ b/Scripts/Source/MantellaMCM.psc
@@ -228,7 +228,7 @@ Event OnOptionHighlight (Int optionID)
 		SetInfoText("Periodically reminds the player it is their turn to speak / input text.")
     
     elseIf optionID == oid_keymapStartAddHotkey
-		SetInfoText("Either starts a conversation or adds an NPC to a conversation.")
+		SetInfoText("Either starts a conversation or adds an NPC to a conversation. Press & hold on an NPC to remove them. Press while targeting one npc and release while targeting another to start a radiant conversation. ")
 	elseIf optionID == oid_keymapPromptHotkey
 		SetInfoText("Opens the text prompt or starts the mic recording depending on the context and the microphone options above. \nDefault: H")
 	elseIf optionID == oid_keymapEndHotkey


### PR DESCRIPTION
The add to conversation hotkey can now also
 - Remove from conversation (press, hold & release)
 - Start a radiant conversation (Press on one NPC and release on another while not in a conversation)
