### PR TITLE
Dont generate responses when no npc is in range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.lip
 *.zip
 *.ini
+!MantellaDialogue.ini
 *.bsa
 *.pex
 SKSE/Plugins/MantellaSoftware/

--- a/SKSE/Plugins/MantellaDialogue.ini
+++ b/SKSE/Plugins/MantellaDialogue.ini
@@ -1,0 +1,14 @@
+; If the NPC's reply is less than FilterShortRepliesMinWordCount, Do not send it to Mantella.
+; can help filter out some menus and mod related dialogue options.
+FilterShortReplies=false
+FilterShortRepliesMinWordCount=4
+; filters all player lines and npc responses for greetings that are non unique (ie. can be triggered each time the player starts a conversation with that NPC.)
+FilterNonUniqueGreetings=true
+; If the NPCs response or line is included in one of these, discard both the player's line and the NPCs line.
+NPCLineBlacklist=Can I help you?, Farewell, See you later
+; If the players line is included in these, discard both the players and the NPCs line.
+PlayerLineBlacklist=Stage1Hello, I want you to.., Goodbye. (Remove from Mantella conversation), You.. Come with me. Understand?, Assist me in combat from now on, I want to speak with you. (Start Mantella conversation), Other aspects & orders for you.,Shut the hell up before I back hand you!
+
+; Add the names of the NPCs here for which you do not want to track dialogue (comma seperated)
+; The Names must be the same as they appear in the game.
+NPCNamesToIgnore=

--- a/Scripts/Source/MantellaConstants.psc
+++ b/Scripts/Source/MantellaConstants.psc
@@ -56,6 +56,7 @@ string property KEY_ACTOR_ISPLAYER = "mantella_actor_is_player" auto
 string property KEY_ACTOR_RELATIONSHIPRANK = "mantella_actor_relationshiprank" auto
 string property KEY_ACTOR_VOICETYPE = "mantella_actor_voicetype" auto
 string property KEY_ACTOR_ISINCOMBAT = "mantella_actor_is_in_combat" auto
+string property KEY_ACTOR_ISOUTSIDETALKINGRANGE = "mantella_actor_is_outside_talking_range" auto
 string property KEY_ACTOR_ISENEMY = "mantella_actor_is_enemy" auto
 string property KEY_ACTOR_CUSTOMVALUES = "mantella_actor_custom_values" auto
 

--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -395,9 +395,7 @@ function sendRequestForPlayerInput(string playerInput, bool updateContext)
         SKSE_HTTP.setString(handle, mConsts.KEY_REQUESTTYPE, mConsts.KEY_REQUESTTYPE_PLAYERINPUT)
         SKSE_HTTP.setString(handle, mConsts.KEY_REQUESTTYPE_PLAYERINPUT, playerinput)
 
-        if repository.targetTrackingAngerState ; only the anger state of the NPCs is updated by UpdateNpcsInConversationArray()
-            UpdateNpcsInConversationArray()
-        endIf
+        UpdateNpcsInConversationArray()
         SKSE_HTTP.setNestedDictionariesArray(handle, mConsts.KEY_ACTORS, _actorHandles)
 
         if updateContext ; if context has not been refreshed recently
@@ -797,7 +795,10 @@ int[] function UpdateNpcsInConversationArray()
     int i = 0
     While i < Participants.GetSize()
         Actor actorToBuild = Participants.GetAt(i) as Actor
-        SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
+        if repository.targetTrackingAngerState ; only the anger state of the NPCs is updated by UpdateNpcsInConversationArray()
+            SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
+        endIf
+        SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > 4096) ; TODO: make a setting or get voice distance dynamically
         i += 1
     EndWhile
 endFunction

--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -798,7 +798,9 @@ int[] function UpdateNpcsInConversationArray()
         if repository.targetTrackingAngerState ; only the anger state of the NPCs is updated by UpdateNpcsInConversationArray()
             SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
         endIf
-        SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > 4096) ; TODO: make a setting or get voice distance dynamically
+        Debug.Notification(actorToBuild.GetDistance(PlayerRef))
+        Debug.Notification(repository.targetMaxDistance)    
+        SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > repository.targetMaxDistance) 
         i += 1
     EndWhile
 endFunction
@@ -815,9 +817,11 @@ int function buildActorSetting(Actor actorToBuild)
     SKSE_HTTP.setInt(handle, mConsts.KEY_ACTOR_RELATIONSHIPRANK, actorToBuild.getrelationshiprank(PlayerRef))
     SKSE_HTTP.setString(handle, mConsts.KEY_ACTOR_VOICETYPE, actorToBuild.GetVoiceType())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
+    SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > repository.targetMaxDistance) 
+    Debug.Notification(repository.targetMaxDistance)  
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISENEMY, actorToBuild.getcombattarget() == PlayerRef)
     EquipmentDescriber.AddEquipmentDescription(handle, actorToBuild, isPlayerCharacter, repository)
-    int customActorValuesHandle = SKSE_HTTP.createDictionary()
+    int customActorValuesHandle = SKSE_HTTP.createDictionary() 
     If (isPlayerCharacter)
         AddCustomPCValues(customActorValuesHandle, actorToBuild)
     EndIf

--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -108,6 +108,7 @@ function StartConversation(Actor[] actorsToStartConversationWith)
     if (eventHandle)        
         ModEvent.Send(eventHandle)
     endIf 
+    MantellaVanillaDialogue.notifyConversationStart()
 endFunction
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -369,6 +370,7 @@ Function CleanupConversation()
     if (handle)        
         ModEvent.Send(handle)
     endIf 
+    MantellaVanillaDialogue.notifyConversationEnd()
     Debug.Notification("Conversation ended.")  
     Stop()
 EndFunction
@@ -557,6 +559,7 @@ Function SendActorAddedEvents(Form[] actorsAdded)
         EndIf
         index += 1
     EndWhile
+    MantellaVanillaDialogue.notifyNpcAdded(actorsAdded)
 EndFunction
 
 Function SendActorRemovedEvents(Form[] actorsRemoved)
@@ -570,6 +573,7 @@ Function SendActorRemovedEvents(Form[] actorsRemoved)
         endIf 
         index += 1
     EndWhile
+    MantellaVanillaDialogue.notifyNpcRemoved(actorsRemoved)
 EndFunction
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -798,9 +798,14 @@ int[] function UpdateNpcsInConversationArray()
         if repository.targetTrackingAngerState ; only the anger state of the NPCs is updated by UpdateNpcsInConversationArray()
             SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
         endIf
-        Debug.Notification(actorToBuild.GetDistance(PlayerRef))
-        Debug.Notification(repository.targetMaxDistance)    
         SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > repository.targetMaxDistance) 
+
+        Float distanceToPlayer = actorToBuild.GetDistance(PlayerRef)
+        if repository.autoRemoveNpcsFromConversation == true && distanceToPlayer > repository.autoRemoveMaxDistance && distanceToPlayer < 620000 ; When both actors are in different cells, distance is huge and we dont want to remove when in different cells
+            Actor[] actors = new Actor[1]
+            actors[0] = actorToBuild
+            RemoveActorsFromConversation(actors)
+        endif
         i += 1
     EndWhile
 endFunction
@@ -818,7 +823,6 @@ int function buildActorSetting(Actor actorToBuild)
     SKSE_HTTP.setString(handle, mConsts.KEY_ACTOR_VOICETYPE, actorToBuild.GetVoiceType())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISINCOMBAT, actorToBuild.IsInCombat())
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > repository.targetMaxDistance) 
-    Debug.Notification(repository.targetMaxDistance)  
     SKSE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISENEMY, actorToBuild.getcombattarget() == PlayerRef)
     EquipmentDescriber.AddEquipmentDescription(handle, actorToBuild, isPlayerCharacter, repository)
     int customActorValuesHandle = SKSE_HTTP.createDictionary() 

--- a/Scripts/Source/MantellaConversation.psc
+++ b/Scripts/Source/MantellaConversation.psc
@@ -801,7 +801,7 @@ int[] function UpdateNpcsInConversationArray()
         SKSE_HTTP.setBool(_actorHandles[i], mConsts.KEY_ACTOR_ISOUTSIDETALKINGRANGE, actorToBuild.GetDistance(PlayerRef) > repository.targetMaxDistance) 
 
         Float distanceToPlayer = actorToBuild.GetDistance(PlayerRef)
-        if repository.autoRemoveNpcsFromConversation == true && distanceToPlayer > repository.autoRemoveMaxDistance && distanceToPlayer < 620000 ; When both actors are in different cells, distance is huge and we dont want to remove when in different cells
+        if repository.autoRemoveNpcsFromConversation == true && Participants.GetSize() > 2 && distanceToPlayer > repository.autoRemoveMaxDistance && distanceToPlayer < 620000 ; When both actors are in different cells, distance is huge and we dont want to remove when in different cells
             Actor[] actors = new Actor[1]
             actors[0] = actorToBuild
             RemoveActorsFromConversation(actors)

--- a/Scripts/Source/MantellaMCM.psc
+++ b/Scripts/Source/MantellaMCM.psc
@@ -89,6 +89,7 @@ int property oid_AllowForNPCtoFollowToggle auto ;gia
 int property oid_NPCAngerToggle auto ;gia
 int property oid_NPCInventoryToggle auto
 int property oid_NPCPackageToggle auto
+int property oid_enableVanillaDialogueAwareness auto
 
 int property oid_debugNPCSelectMode auto
 int property oid_restartMantellaExe Auto
@@ -111,7 +112,7 @@ string MantellaMCMcurrentPage
 ; Whenever a new repository value OR a new MCM setting is added, up the MCM version number returned by `ManatellaMCM.GetVersion()`
 ; and add the corresponding default value in 'MCMRepository.assignDefaultSettings' in a block corresponding to the version number like the examples
 int Function GetVersion()
-    Return 6
+    Return 7
 EndFunction
 
 event OnVersionUpdate(int a_version)
@@ -360,6 +361,8 @@ Event OnOptionHighlight (Int optionID)
 		SetInfoText("NPCs can open their inventory to share items.")
 	elseIf optionID == oid_NPCPackageToggle
 		SetInfoText("NPCs will stop to talk to you and will not engage in non-Mantella conversations.")
+	elseIf optionID == oid_enableVanillaDialogueAwareness
+		SetInfoText("NPCs will know about any dialogue spoken in the vanilla dialogue system.")
 
 	elseIf optionID == oid_debugNPCSelectMode
 		SetInfoText("Allows the player to speak to any NPC by initiating a conversation then entering the actor RefID and actor name that the player wishes to speak to")

--- a/Scripts/Source/MantellaMCM.psc
+++ b/Scripts/Source/MantellaMCM.psc
@@ -83,7 +83,11 @@ int property oid_targetEquipmentRightHand auto
 int property oid_targetEquipmentLeftHand auto
 int property oid_targetEquipmentAll auto
 bool property targetEquipmentAllToggle auto
+
+int property oid_autoRemoveNpcsFromConversation auto
 int property oid_targetMaxDistance	auto
+int property oid_autoRemoveMaxDistance auto
+
 
 int property oid_AllowForNPCtoFollowToggle auto ;gia
 int property oid_NPCAngerToggle auto ;gia
@@ -112,7 +116,7 @@ string MantellaMCMcurrentPage
 ; Whenever a new repository value OR a new MCM setting is added, up the MCM version number returned by `ManatellaMCM.GetVersion()`
 ; and add the corresponding default value in 'MCMRepository.assignDefaultSettings' in a block corresponding to the version number like the examples
 int Function GetVersion()
-    Return 8
+    Return 9
 EndFunction
 
 event OnVersionUpdate(int a_version)
@@ -202,7 +206,9 @@ Event OnOptionSliderAccept(Int optionId, Float value)
         MantellaMCM_PlayerSettings.SliderOptionAccept(self,optionID, value, repository)
     elseif MantellaMCMcurrentPage == PAGE_ADVANCED
         MantellaMCM_AdvancedSettings.SliderOptionAccept(self,optionID, value, repository)
-    endIf
+	elseif MantellaMCMcurrentPage == PAGE_TARGETTRACKING
+		MantellaMCM_TargetTrackingSettings.SliderOptionAccept(self,optionID, value, repository)
+	endIf
 EndEvent
 
 Event OnOptionKeyMapChange(Int a_option, Int a_keyCode, String a_conflictControl, String a_conflictName)

--- a/Scripts/Source/MantellaMCM.psc
+++ b/Scripts/Source/MantellaMCM.psc
@@ -83,7 +83,7 @@ int property oid_targetEquipmentRightHand auto
 int property oid_targetEquipmentLeftHand auto
 int property oid_targetEquipmentAll auto
 bool property targetEquipmentAllToggle auto
-
+int property oid_targetMaxDistance	auto
 
 int property oid_AllowForNPCtoFollowToggle auto ;gia
 int property oid_NPCAngerToggle auto ;gia
@@ -112,7 +112,7 @@ string MantellaMCMcurrentPage
 ; Whenever a new repository value OR a new MCM setting is added, up the MCM version number returned by `ManatellaMCM.GetVersion()`
 ; and add the corresponding default value in 'MCMRepository.assignDefaultSettings' in a block corresponding to the version number like the examples
 int Function GetVersion()
-    Return 7
+    Return 8
 EndFunction
 
 event OnVersionUpdate(int a_version)
@@ -190,7 +190,9 @@ Event OnOptionSliderOpen(Int optionId)
         MantellaMCM_PlayerSettings.SliderOptionOpen(self,optionID, repository)
     elseif MantellaMCMcurrentPage == PAGE_ADVANCED
         MantellaMCM_AdvancedSettings.SliderOptionOpen(self,optionID, repository)
-    endIf
+	elseif MantellaMCMcurrentPage == PAGE_TARGETTRACKING
+		MantellaMCM_TargetTrackingSettings.SliderOptionOpen(self,optionID, repository)	
+	endIf
 EndEvent
 
 Event OnOptionSliderAccept(Int optionId, Float value)
@@ -351,8 +353,8 @@ Event OnOptionHighlight (Int optionID)
 		SetInfoText("Describe item in the left hand of the target to the LLM.")
 	elseIf optionID == oid_targetEquipmentAll
 		SetInfoText("Enable / disable all description options for the target.")
-
-
+	elseIf optionID == oid_targetMaxDistance
+		SetInfoText("Maximum distance from the player below which npc's can reply to the player. 2500 Units are 120ft or 36m")
 	elseIf optionID == oid_AllowForNPCtoFollowToggle ;gia
 		SetInfoText("NPCs can be convinced to follow (not tested over long playthroughs).")
 	elseIf optionID == oid_NPCAngerToggle ;gia
@@ -368,6 +370,7 @@ Event OnOptionHighlight (Int optionID)
 		SetInfoText("Allows the player to speak to any NPC by initiating a conversation then entering the actor RefID and actor name that the player wishes to speak to")
 	elseif optionID == oid_httpPort
 		SetInfoText("HTTP port for Mantella to call. If you need to change the default port, change it here and the port for MantellaSoftware's server in its config.ini. Default: 4999")
+
 	EndIf
 endEvent
 

--- a/Scripts/Source/MantellaMCM_GeneralSettings.psc
+++ b/Scripts/Source/MantellaMCM_GeneralSettings.psc
@@ -53,7 +53,7 @@ function SliderOptionOpen(MantellaMCM mcm, int optionID, MantellaRepository Repo
     elseIf optionID==mcm.oid_radiantfrequency
         mcm.SetSliderDialogStartValue(repository.radiantFrequency)
         mcm.SetSliderDialogDefaultValue(10)
-        mcm.SetSliderDialogRange(5, 300)
+        mcm.SetSliderDialogRange(5, 300)    
         mcm.SetSliderDialogInterval(1)
     endif
 endfunction

--- a/Scripts/Source/MantellaMCM_GeneralSettings.psc
+++ b/Scripts/Source/MantellaMCM_GeneralSettings.psc
@@ -34,7 +34,8 @@ function RightColumn(MantellaMCM mcm, MantellaRepository Repository) global
 	mcm.oid_NPCAngerToggle = mcm.AddToggleOption("Allow Aggro", Repository.NPCAnger)
     mcm.oid_NPCInventoryToggle = mcm.AddToggleOption("Allow Inventory", Repository.NPCInventory)
     mcm.oid_NPCPackageToggle = mcm.AddToggleOption("NPCs Stop to Talk", Repository.NPCPackage)
-    mcm.oid_showDialogueItems = mcm.AddToggleOption("Show Dialogue Items", repository.showDialogueItems)   
+    mcm.oid_showDialogueItems = mcm.AddToggleOption("Show Dialogue Items", repository.showDialogueItems) 
+    mcm.oid_enableVanillaDialogueAwareness = mcm.AddToggleOption("Enable Vanilla Dialogue Awareness", repository.enableVanillaDialogueAwareness)
 endfunction
 
 function SliderOptionOpen(MantellaMCM mcm, int optionID, MantellaRepository Repository) global
@@ -157,5 +158,8 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
     elseIf optionID == mcm.oid_NPCPackageToggle
         Repository.NPCPackage =! Repository.NPCPackage
         mcm.SetToggleOptionValue(mcm.oid_NPCPackageToggle, Repository.NPCPackage)
+    elseIf optionID == mcm.oid_enableVanillaDialogueAwareness
+        Repository.enableVanillaDialogueAwareness =! Repository.enableVanillaDialogueAwareness
+        mcm.SetToggleOptionValue(mcm.oid_enableVanillaDialogueAwareness, Repository.enableVanillaDialogueAwareness)
     endif
 endfunction

--- a/Scripts/Source/MantellaMCM_TargetTrackingSettings.psc
+++ b/Scripts/Source/MantellaMCM_TargetTrackingSettings.psc
@@ -6,7 +6,7 @@ function Render(MantellaMCM mcm, MantellaRepository Repository) global
     mcm.SetCursorFillMode(mcm.TOP_TO_BOTTOM)
     LeftColumn(mcm, Repository)
     mcm.SetCursorPosition(1)
-    RightColumn(mcm)
+    RightColumn(mcm, Repository)
 endfunction
 
 function LeftColumn(MantellaMCM mcm, MantellaRepository Repository) global
@@ -25,7 +25,7 @@ function LeftColumn(MantellaMCM mcm, MantellaRepository Repository) global
     mcm.oid_targetTrackingAll = mcm.AddToggleOption("All", mcm.targetAllToggle)
 endfunction
 
-function RightColumn(MantellaMCM mcm) global
+function RightColumn(MantellaMCM mcm, MantellaRepository repository) global
      ;This part of the MCM MainSettings script pretty much only serves to tell papyrus what button to display using properties from the repository
     ;generates left column
     mcm.AddHeaderOption ("Target Info")
@@ -82,6 +82,10 @@ function RightColumn(MantellaMCM mcm) global
     mcm.AddTextOption("Relationship",currentActorRelationshipString )
     mcm.AddTextOption("Voice Type",currentActorVoiceSubstring )
     mcm.AddTextOption("Enemy",currentActorIsEnemy )
+
+    mcm.AddHeaderOption("Conversation")
+    mcm.oid_targetMaxDistance = mcm.AddSliderOption("Maximum npc distance", repository.targetMaxDistance)    
+
     ;_keymapOID_K = mcm.AddKeyMapOption("Mantella Initiate/Text Hotkey", _myKey, 0)
 endfunction
 
@@ -147,3 +151,12 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
         
     endif
 endfunction 
+
+function SliderOptionOpen(MantellaMCM mcm, int optionID, MantellaRepository Repository) global
+    if optionID==mcm.oid_targetMaxDistance
+        mcm.SetSliderDialogStartValue(Repository.targetMaxDistance)
+        mcm.SetSliderDialogDefaultValue(2500)
+        mcm.SetSliderDialogRange(0, 10000)
+        mcm.SetSliderDialogInterval(100)
+    endif
+endfunction

--- a/Scripts/Source/MantellaMCM_TargetTrackingSettings.psc
+++ b/Scripts/Source/MantellaMCM_TargetTrackingSettings.psc
@@ -84,8 +84,9 @@ function RightColumn(MantellaMCM mcm, MantellaRepository repository) global
     mcm.AddTextOption("Enemy",currentActorIsEnemy )
 
     mcm.AddHeaderOption("Conversation")
-    mcm.oid_targetMaxDistance = mcm.AddSliderOption("Maximum npc distance", repository.targetMaxDistance)    
-
+    mcm.oid_autoRemoveNpcsFromConversation = mcm.AddToggleOption("Auto remove NPCs from conversation", repository.autoRemoveNpcsFromConversation)  
+    mcm.oid_targetMaxDistance = mcm.AddSliderOption("Npc hearing range", repository.targetMaxDistance)  
+    mcm.oid_autoRemoveMaxDistance = mcm.AddSliderOption("Auto remove distance", repository.autoRemoveMaxDistance)
     ;_keymapOID_K = mcm.AddKeyMapOption("Mantella Initiate/Text Hotkey", _myKey, 0)
 endfunction
 
@@ -148,9 +149,22 @@ function OptionUpdate(MantellaMCM mcm, int optionID, MantellaRepository Reposito
         Repository.targetTrackingAngerState=mcm.targetAllToggle
         ;not using dying toggle cause this one is to end conversations on NPC death
         ;Repository.targetTrackingOnDying=mcm.targetAllToggle
-        
+    elseif optionID==mcm.oid_autoRemoveNpcsFromConversation
+        Repository.autoRemoveNpcsFromConversation=!Repository.autoRemoveNpcsFromConversation
+        mcm.SetToggleOptionValue( mcm.oid_autoRemoveNpcsFromConversation, Repository.autoRemoveNpcsFromConversation)
     endif
 endfunction 
+
+function SliderOptionAccept(MantellaMCM mcm, int optionID, float value, MantellaRepository Repository) global
+    ;SliderOptionAccept is used to update the Repository with the user input (that input will then be used by the Mantella effect script
+    If  optionId == mcm.oid_targetMaxDistance
+        mcm.SetSliderOptionValue(optionId, value)
+        Repository.targetMaxDistance = value as int
+    ElseIf optionId == mcm.oid_autoRemoveMaxDistance
+        mcm.SetSliderOptionValue(optionId, value)
+        Repository.autoRemoveMaxDistance = value as int
+    EndIf
+endfunction
 
 function SliderOptionOpen(MantellaMCM mcm, int optionID, MantellaRepository Repository) global
     if optionID==mcm.oid_targetMaxDistance
@@ -158,5 +172,10 @@ function SliderOptionOpen(MantellaMCM mcm, int optionID, MantellaRepository Repo
         mcm.SetSliderDialogDefaultValue(2500)
         mcm.SetSliderDialogRange(0, 10000)
         mcm.SetSliderDialogInterval(100)
+    elseif optionID==mcm.oid_autoRemoveMaxDistance
+        mcm.SetSliderDialogStartValue(Repository.autoRemoveMaxDistance)
+        mcm.SetSliderDialogDefaultValue(9000)
+        mcm.SetSliderDialogRange(0, 20000)
+        mcm.SetSliderDialogInterval(200)
     endif
 endfunction

--- a/Scripts/Source/MantellaRepository.psc
+++ b/Scripts/Source/MantellaRepository.psc
@@ -89,7 +89,7 @@ bool property targetEquipmentAmulet auto
 bool property targetEquipmentRightHand auto
 bool property targetEquipmentLeftHand auto
 
-
+bool property enableVanillaDialogueAwareness auto
 bool property AllowForNPCtoFollow auto ;gia
 ;bool property followingNPCsit auto ;gia
 ;bool property followingNPCsleep auto ;gia
@@ -121,6 +121,9 @@ endEvent
 ; and add the corresponding default value here in a block corresponding to the version number like the examples below
 ; Doing it like this will only assign the defaul values to settings that haven't been initialised prior.
 function assignDefaultSettings(int lastVersion, bool isFirstInit = false)
+    If (lastVersion < 7 || isFirstInit)
+        enableVanillaDialogueAwareness = true
+    EndIf
     If (lastVersion < 6 || isFirstInit)
         NPCInventory = false
     EndIf

--- a/Scripts/Source/MantellaRepository.psc
+++ b/Scripts/Source/MantellaRepository.psc
@@ -88,6 +88,8 @@ bool property targetEquipmentFeet auto
 bool property targetEquipmentAmulet auto
 bool property targetEquipmentRightHand auto
 bool property targetEquipmentLeftHand auto
+bool Property autoRemoveNpcsFromConversation Auto
+int  Property autoRemoveMaxDistance auto  
 int  property targetMaxDistance auto
 
 bool property enableVanillaDialogueAwareness auto
@@ -122,7 +124,10 @@ endEvent
 ; and add the corresponding default value here in a block corresponding to the version number like the examples below
 ; Doing it like this will only assign the defaul values to settings that haven't been initialised prior.
 function assignDefaultSettings(int lastVersion, bool isFirstInit = false)
-    If (lastVersion < 8 || isFirstInit)
+    If(lastVersion < 9 || isFirstInit)
+        autoRemoveNpcsFromConversation = true
+        autoRemoveMaxDistance = 9000
+    elseIf (lastVersion < 8 || isFirstInit)
         targetMaxDistance = 2500
     EndIf   
     If (lastVersion < 7 || isFirstInit)

--- a/Scripts/Source/MantellaRepository.psc
+++ b/Scripts/Source/MantellaRepository.psc
@@ -127,6 +127,7 @@ function assignDefaultSettings(int lastVersion, bool isFirstInit = false)
     If(lastVersion < 9 || isFirstInit)
         autoRemoveNpcsFromConversation = true
         autoRemoveMaxDistance = 9000
+        targetMaxDistance = 2500
     elseIf (lastVersion < 8 || isFirstInit)
         targetMaxDistance = 2500
     EndIf   

--- a/Scripts/Source/MantellaRepository.psc
+++ b/Scripts/Source/MantellaRepository.psc
@@ -88,6 +88,7 @@ bool property targetEquipmentFeet auto
 bool property targetEquipmentAmulet auto
 bool property targetEquipmentRightHand auto
 bool property targetEquipmentLeftHand auto
+int  property targetMaxDistance auto
 
 bool property enableVanillaDialogueAwareness auto
 bool property AllowForNPCtoFollow auto ;gia
@@ -121,6 +122,9 @@ endEvent
 ; and add the corresponding default value here in a block corresponding to the version number like the examples below
 ; Doing it like this will only assign the defaul values to settings that haven't been initialised prior.
 function assignDefaultSettings(int lastVersion, bool isFirstInit = false)
+    If (lastVersion < 8 || isFirstInit)
+        targetMaxDistance = 2500
+    EndIf   
     If (lastVersion < 7 || isFirstInit)
         enableVanillaDialogueAwareness = true
     EndIf

--- a/Scripts/Source/MantellaVanillaDialogue.psc
+++ b/Scripts/Source/MantellaVanillaDialogue.psc
@@ -1,0 +1,7 @@
+scriptname MantellaVanillaDialogue hidden
+
+;Forwards event to the SKSE Dialogue tracker 
+    function notifyConversationStart() global native
+    function notifyConversationEnd() global native
+    function notifyNpcAdded(Form[] added) global native
+    function notifyNpcRemoved(Form[] removed) global native


### PR DESCRIPTION
Checks the distance of each participant during a conversation, prevents them from speaking if they are too far away
There are two modes for this: 
 - If there is at least one npc in range to talk, an event gets added about who is too far away & cant reply
 - If all are too far away, the players input is not sent to the llm at all

This is done by sending a bool `KEY_ACTOR_ISOUTSIDETALKINGRANGE` along for each npc in the conversation. 

Additionally, there is an option to remove npcs from conversation if they get even further away. This will not remove npcs when there is only one left (It wont end the conversation)

MCM Options added:
- A bool wether to remove far away npcs
- A distance threshold for removal
- A distance threshold for silencing

